### PR TITLE
Fix tweetnacl URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "superagent": "^0.18.0",
         "gulp-uglify": "~0.3.0",
         "gulp-rename": "~1.2.0",
-        "tweetnacl": "git+ssh://git@github.com:stellar/tweetnacl-js.git"
+        "tweetnacl": "git+https://github.com/stellar/tweetnacl-js.git"
     },
     "devDependencies": {
         "mocha": "~1.14.0",


### PR DESCRIPTION
Pulling a repo from github using SSH requires permissions to the repo.
Change it to HTTPS so that stellar/tweetnacl-js can be loaded by developers outside of the organization.

Fixes #11.
