### PR TITLE
ter means error not retry, only retry when told to

### DIFF
--- a/src/transactionmanager.js
+++ b/src/transactionmanager.js
@@ -440,7 +440,11 @@ TransactionManager.prototype._request = function(tx) {
         transactionFeeClaimed(message);
         break;
       case 'ter':
-        transactionRetry(message);
+        if (message.result == 'terRETRY') {
+          transactionRetry(message);
+        } else {
+          transactionFailed(message);
+        }
         break;
       case 'tef':
         transactionFailed(message);


### PR DESCRIPTION
Requests that return status `ter...` were being resubmitted, but got into a state where the callback was never called.
Since `ter` means transaction error, we should not be trying to resubmit it.
Go ahead and allow the `terRetry` status to retry, but send the rest of the statuses through the failure handler so the error is properly returned.

Fixes #17.
