### PR TITLE
Use exponential back off for connection retries

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -388,17 +388,7 @@ Server.prototype._retryConnect = function() {
 
   this._retry += 1;
 
-  var retryTimeout = (this._retry < 40)
-  // First, for 2 seconds: 20 times per second
-  ? (1000 / 20)
-  : (this._retry < 40 + 60)
-  // Then, for 1 minute: once per second
-  ? (1000)
-  : (this._retry < 40 + 60 + 60)
-  // Then, for 10 minutes: once every 10 seconds
-  ? (10 * 1000)
-  // Then: once every 30 seconds
-  : (30 * 1000);
+  var retryTimeout = util.expBackoff(this._retry, 100, 1000);
 
   function connectionRetry() {
     if (self._shouldConnect) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -136,6 +136,24 @@ function fromTimestamp(rpepoch) {
   return Math.round(rpepoch / 1000) - 0x386D4380;
 };
 
+/**
+ *  Exponentially increases the average time between tries.
+ *
+ * @param {Number} tries The number of times that an action was tried, but failed.
+ * @param {Number} [gain] The constant used to linearly transform (multiply to) the time.
+ * @param {Number} [offset] The constant used to linearly offset (add to) the time.
+ */
+function expBackoff(tries, gain, offset) {
+  gain = gain || 1;
+  offset = offset || 0;
+
+  // http://en.wikipedia.org/wiki/Exponential_backoff
+  var t = Math.random() * (Math.pow(2, tries) - 1);
+
+  // https://code.google.com/p/google-http-java-client/wiki/ExponentialBackoff
+  return offset + gain * t;
+}
+
 exports.time = {
   fromStellar: toTimestamp,
   toStellar: fromTimestamp
@@ -152,3 +170,4 @@ exports.assert        = assert;
 exports.arrayUnique   = arrayUnique;
 exports.toTimestamp   = toTimestamp;
 exports.fromTimestamp = fromTimestamp;
+exports.expBackoff    = expBackoff;


### PR DESCRIPTION
The logic used to delay reconnection attempts was too permissive.

Use a randomized exponential backoff.
The maximum timeout is (1000 + 100·(2<sup>n</sup> - 1)) ms on the n'th try.

Fixes #3.

Example:

```
1: 1031ms
2: 1026ms
3: 1123ms
4: 1141ms
5: 1767ms
6: 5186ms
7: 11767ms
8: 24392ms
9: 44311ms
10: 83400ms
```
