### PR TITLE
Use the prebuilt sjcl fork, remove gulp sjcl task

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -16,7 +16,7 @@ var banner = '/*! <%= pkg.name %> - v<%= pkg.version %> - '
 + '* Copyright (c) <%= new Date().getFullYear() %> <%= pkg.author.name %>;'
 + ' Licensed <%= pkg.license %> */'
 
-gulp.task('build', [ 'sjcl' ], function(callback) {
+gulp.task('build', [], function(callback) {
   webpack({
     cache: true,
     entry: './src/index.js',
@@ -47,14 +47,6 @@ gulp.task('build-debug', [], function(callback) {
     debug: true,
     devtool: 'eval'
   }, callback);
-});
-
-gulp.task('sjcl', [], function(callback) {
-  // Add required components to the sjcl config and rebuild it.
-  return gulp.src('./config/sjcl.config.mk')
-    .pipe(rename('config.mk'))
-    .pipe(gulp.dest('./node_modules/sjcl/'))
-    .pipe(exec('make -C ./node_modules/sjcl/'));
 });
 
 gulp.task('lint', function() {

--- a/config/sjcl.config.mk
+++ b/config/sjcl.config.mk
@@ -1,2 +1,0 @@
-SOURCES= core/sjcl.js core/aes.js core/bitArray.js core/codecString.js core/codecHex.js core/codecBase64.js core/sha256.js core/ccm.js core/ocb2.js core/gcm.js core/hmac.js core/pbkdf2.js core/random.js core/convenience.js core/bn.js core/codecBytes.js core/sha512.js core/sha1.js
-COMPRESS= core_closure.js

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "gulp-uglify": "~0.3.0",
         "gulp-rename": "~1.2.0",
         "tweetnacl": "git+https://github.com/stellar/tweetnacl-js.git",
-        "sjcl": "~1.0.0",
+        "sjcl": "git+https://github.com/stellar/sjcl.git",
         "jsbn": "~0.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
Use the preconfigured/prebuilt fork of sjcl to avoid `make`ing sjcl during the build process.
