### PR TITLE
Remove default lastLedgerSequence value

### DIFF
--- a/src/js/ripple/transaction.js
+++ b/src/js/ripple/transaction.js
@@ -479,8 +479,8 @@ Transaction.prototype.clientID = function(id) {
 
 Transaction.prototype.lastLedger = function(sequence) {
   if (typeof sequence === 'number') {
-    this._setLastLedger = true;
     this.tx_json.LastLedgerSequence = sequence;
+    this.lastLedgerSequence = sequence;
   }
   return this;
 };

--- a/src/js/ripple/transactionmanager.js
+++ b/src/js/ripple/transactionmanager.js
@@ -559,14 +559,6 @@ TransactionManager.prototype._request = function(tx) {
     tx.initialSubmitIndex = tx.submitIndex;
   }
 
-  if (!tx._setLastLedger) {
-    // Honor LastLedgerSequence set by user of API. If
-    // left unset by API, bump LastLedgerSequence
-    tx.tx_json.LastLedgerSequence = tx.submitIndex + 8;
-  }
-
-  tx.lastLedgerSequence = tx.tx_json.LastLedgerSequence;
-
   if (remote.local_signing) {
     tx.sign(prepareSubmit);
   } else {

--- a/test/transaction-test.js
+++ b/test/transaction-test.js
@@ -811,11 +811,11 @@ describe('Transaction', function() {
 
     transaction.lastLedger('a');
     assert.strictEqual(transaction.tx_json.LastLedgerSequence, void(0));
-    assert(!transaction._setLastLedger);
+    assert.strictEqual(transaction.lastLedgerSequence, void(0));
 
     transaction.lastLedger(12);
     assert.strictEqual(transaction.tx_json.LastLedgerSequence, 12);
-    assert(transaction._setLastLedger);
+    assert.strictEqual(transaction.lastLedgerSequence, 12);
   });
 
   it('Rewrite transaction path', function() {


### PR DESCRIPTION
https://github.com/stellar/stellar-client/issues/876

Remove the default lastLedgerSequence when no sequence is specified.
Remove unnecessary set flag.
Add the lastLedgerSequence property to the root tx and it's json in the same place.
Update the tests.
