### PR TITLE
gets rid of unused dependencies `url` and `querystring` in crypt.js

### DIFF
--- a/src/js/ripple/crypt.js
+++ b/src/js/ripple/crypt.js
@@ -4,9 +4,7 @@ var Seed        = require('./seed').Seed;
 var UInt160     = require('./uint160').UInt160;
 var UInt256     = require('./uint256').UInt256;
 var request     = require('superagent');
-var querystring = require('querystring');
 var extend      = require("extend");
-var parser      = require("url");
 var ripemd160   = require("ripemd160");
 var Crypt       = { };
 


### PR DESCRIPTION
Dependencies on `url` and `querystring` in this file have been removed.

When using this library in React Native (in my case, solely for key generation), I don't have access to the native node `url` and `querystring` modules, which, while required in this file, are unused here.
